### PR TITLE
Update RPM Maven plugin URL from Codehaus to Mojohaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As a proof of concept I implemented a Hazelcast server that does its best to ful
 * found a [solution](https://github.com/obergner/hazelcast-server/tree/master/base/src/main/java/com/obergner/hzserver) for modularizing Hazelcast's usually monolithic XML configuration,
 * exposed a few select MBean attributes via SNMP, using Torsten Curdt's excellent little [jmx2snmp](https://github.com/tcurdt/jmx2snmp) library (since operations is having a hard time integrating MBeans and [Icinga](https://www.icinga.org/)),
 * plugged all the pieces into each other using [Spring](http://www.springsource.org/), an IOC container you might have heard of already,
-* wrapped the result into an RPM package *hazelcast-server-base* using the rather useful [RPM Maven Plugin](http://mojo.codehaus.org/rpm-maven-plugin/), where that RPM includes neither configuration nor a service script (hint: Configurationless Application),
+* wrapped the result into an RPM package *hazelcast-server-base* using the rather useful [RPM Maven Plugin](http://www.mojohaus.org/rpm-maven-plugin/), where that RPM includes neither configuration nor a service script (hint: Configurationless Application),
 * bundled a sample Hazelcast XML configuration file and a script for running *hazelcast-server* as a linux service - using *Tanuki Software's* as always flawless [Java Service Wrapper](http://wrapper.tanukisoftware.com/doc/german/download.jsp) - into another RPM, *hazelcast-server-service*, that declares a dependency on *hazelcast-server-base*, and
 * bundled some sample map and queue defintions into yet another RPM, *hazelcast-server-app*, to demonstrate how one would go about deploying application-specific resources into a central Hazelcast server.
 


### PR DESCRIPTION
Just came across that broken link while reading this interesting document.
I hope I'm not wrong about the new URL?
